### PR TITLE
Fixes in logic responsible for moving graph back

### DIFF
--- a/EZAudio/EZAudioUtilities.h
+++ b/EZAudio/EZAudioUtilities.h
@@ -520,8 +520,9 @@ typedef NSRect EZRect;
 
 //------------------------------------------------------------------------------
 
-+ (void)removeEndWithSize:(UInt32)bufferSizeToRemove
-          fromHistoryInfo:(EZPlotHistoryInfo *)historyInfo;
++ (void)updateBufferSize:(UInt32)requestedBufferSize
+         byRemovingBytes:(UInt32)bufferSizeToRemove
+         fromHistoryInfo:(EZPlotHistoryInfo *)historyInfo;
 
 
 //------------------------------------------------------------------------------

--- a/EZAudio/EZAudioUtilities.m
+++ b/EZAudio/EZAudioUtilities.m
@@ -677,7 +677,7 @@ BOOL __shouldExitOnCheckResultFail = YES;
     int32_t requestedBufferSizeInBytes = requestedBufferSize * sizeof(float);
 
     int32_t bytesAvailableForRead = 0;
-    float *historyBuffer = TPCircularBufferTail(&historyInfo->circularBuffer, &bytesAvailableForRead); //pointer do czytania
+    float *historyBuffer = TPCircularBufferTail(&historyInfo->circularBuffer, &bytesAvailableForRead);
 
     //how many floats can be potentially copied from circular buffer
     int32_t numberOfBytesThatCanBePotentiallyCopiedFromCircularBuffer = MAX(bytesAvailableForRead - bufferSizeToRemoveInBytes, 0);


### PR DESCRIPTION
This PR fixes some problems with logic responsible for moving graph back. Previous version didn't work correctly in all cases - especially when we tried to move to history so old that we didn't have data for that period of time.

@bartekchlebek 🎁 
